### PR TITLE
readme: fix node api link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # celestia-openrpc
 
-OpenRPC is a client of [celestia-node RPC](https://docs.celestia.org/category/rpc-api/), without depenencies on celestia-node/celestia-app/cosmos-sdk.
+OpenRPC is a client of [celestia-node RPC](https://docs.celestia.org/developers/node-api/), without depenencies on celestia-node/celestia-app/cosmos-sdk.
 
 This is a temporary measure to resolve dependency issues when celestia-node is imported by rollkit.


### PR DESCRIPTION

## Overview

Fixes broken link to node rpc api docs.

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
