### PR TITLE
chore!: Bumps celestia-node compatibility to v0.11.0

### DIFF
--- a/api.go
+++ b/api.go
@@ -51,7 +51,7 @@ type HeaderAPI struct {
 		ctx context.Context,
 		hash libhead.Hash,
 	) (*header.ExtendedHeader, error) `perm:"read"`
-	GetVerifiedRangeByHeight func(
+	GetRangeByHeight func(
 		context.Context,
 		*header.ExtendedHeader,
 		uint64,


### PR DESCRIPTION
Getter interface from celestia-node broke thanks to go-header

`GetVerifiedRange` is now called `GetRangeByHeight` 

Please keep in mind that this is the method signature: 

```
// GetRangeByHeight returns (fromHead.Height(): to) 
GetRangeByHeight func(ctx context.Context, fromHead *header.ExtendedHeader, to uint64) ([]*header.ExtendedHeader, error) `perm:"read"`
```